### PR TITLE
build: Update actions/checkout

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [ ubuntu-20.04 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build the site with MkDocs
         shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [ ubuntu-20.04 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Docker
         shell: bash


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Overview

<!-- markdownlint-enable MD041 -->

Updated the workflow step of `actions/checkout`.

### Links to issues, related PRs

#11 

### Description

_**Required**, simple description of this PR._

For now, we usually use the `actions/checkout@v2` to checkout our source files into GitHub runner, but GitHub gave warn that the version `v2` is not recommended because of the version of node.js. Ao, we need to update it to the latest version `v4`. The detail of the warning message is as follows:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

### Out of scope

_**Optional**, e.g. issues the reviewers don't need to worry about because they are prevented by other means._

### Implementation details

_**Optional**, e.g. link to design documentation. diagrams etc. as well as additional hints to the reviewers e.g. where to focus when a high number of file is changed._

## Integration test detail

_**Required**, once the entire feature is available: how is integration testing performed, e.g. mention of the current repo test case and branch._

## Checkpoints for reviewers

- _The PR mentions the issue when available (required for non-trivial pull requests)_
- _The PR guidelines are followed (size is manageable, etc.), see <https://github.com>_
- _The coding guidelines are followed (file and function comments, naming conventions etc.), see <https://github.com>_
